### PR TITLE
wifi: Ensure supplicant stopped in wifi_stop_supplicant

### DIFF
--- a/wifi/wifi.c
+++ b/wifi/wifi.c
@@ -873,9 +873,10 @@ int wifi_stop_supplicant(int p2p_supported)
 
     while (count-- > 0) {
         if (property_get(supplicant_prop_name, supp_status, NULL)) {
-            if (strcmp(supp_status, "stopped") == 0)
+            if (strcmp(supp_status, "stopped") == 0) {
                 wifi_stop_fstman(0);
                 return 0;
+            }
         }
         usleep(100000);
     }


### PR DESCRIPTION
Commit 3674b8ab31a628c5d0834890ba3549bf8badf4ea introduces the
wifi_fst module, with a coding mistake, wifi_stop_supplicant
will return even supplicant is not really stopped.
If wifi_start_supplicant is called immediately, race condition
will happen in init process, which makes supplicant not start.

This change is to ensure supplicant really stopped before
wifi_stop_supplicant return.

CYNGNOS-1833, SAMBAR-1266

Change-Id: Ibcf38023a57971ad6e3064b7ab2a98a7a0ed8b99
CRs-Fixed: 958819